### PR TITLE
feat: laravel 10 & 11 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,21 +9,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2]
-        laravel: [9.*]
+        php: [8.1, 8.2, 8.3]
+        laravel: [10.*, 11.*]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
-          - php: 8.2
-            laravel: 9.*
-            dependency-version: prefer-lowest
+          - php: 8.1
+            laravel: 11.*
         include:
-          - laravel: 9.*
-            testbench: 7.*
-          # Laravel only support PHP 8.2 from v9.43
-          - php: 8.2
-            laravel: ^9.43
-            dependency-version: prefer-lowest
-            testbench: 7.*
+          - laravel: 10.*
+            testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     "require": {
         "php": "^8.1",
         "ext-intl": "*",
-        "illuminate/support": "^9.0"
+        "illuminate/support": "^10.0|^11.0"
     },
     "require-dev": {
         "giggsey/libphonenumber-for-php": "^8.12",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^7.0",
-        "phpunit/phpunit": "^9.3.3",
+        "orchestra/testbench": "^8.0|^9.0",
+        "phpunit/phpunit": "^10.5",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "suggest": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+>
     <testsuites>
         <testsuite name="Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>

--- a/tests/Integration/FormatTest.php
+++ b/tests/Integration/FormatTest.php
@@ -37,7 +37,7 @@ class FormatTest extends TestCase
     /**
      * @return \Generator
      */
-    public function provideTestFormats(): Generator
+    public static function provideTestFormats(): Generator
     {
         yield [fn () => Format::text('foo'), 'foo'];
         yield [fn () => Format::accounting(-1234.56, 2), '($1,234.56)'];

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -3,9 +3,9 @@
 namespace Exolnet\Format\Tests\Integration;
 
 use Exolnet\Format\FormatServiceProvider;
-use Orchestra\Testbench\TestCase as Orchestra;
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
-abstract class TestCase extends Orchestra
+abstract class TestCase extends OrchestraTestCase
 {
     /**
      * @param \Illuminate\Foundation\Application $app

--- a/tests/Unit/Formats/FractionFormatTest.php
+++ b/tests/Unit/Formats/FractionFormatTest.php
@@ -23,7 +23,7 @@ class FractionFormatTest extends TestCase
     /**
      * @return array
      */
-    public function provideTestFraction()
+    public static function provideTestFraction()
     {
         return [
             [0.25, 2, '1/2'],
@@ -70,7 +70,7 @@ class FractionFormatTest extends TestCase
     /**
      * @return array
      */
-    public function provideTestFractionSimplified()
+    public static function provideTestFractionSimplified()
     {
         return [
             [0.25, 2, '1/2'],

--- a/tests/Unit/Formats/NumberFormatTest.php
+++ b/tests/Unit/Formats/NumberFormatTest.php
@@ -25,7 +25,7 @@ class NumberFormatTest extends TestCase
     /**
      * @return array
      */
-    public function provideTestNumber()
+    public static function provideTestNumber()
     {
         return [
             [0.00, 0, '0'],

--- a/tests/Unit/Formats/PercentageFormatTest.php
+++ b/tests/Unit/Formats/PercentageFormatTest.php
@@ -23,7 +23,7 @@ class PercentageFormatTest extends TestCase
     /**
      * @return array
      */
-    public function provideTestPercentage()
+    public static function provideTestPercentage()
     {
         return [
             [0.00, 0, '0%'],

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -3,9 +3,9 @@
 namespace Exolnet\Format\Tests\Unit;
 
 use Mockery;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
-abstract class UnitTest extends TestCase
+abstract class TestCase extends BaseTestCase
 {
     /**
      * @return void


### PR DESCRIPTION
This pull request includes updates to support newer versions of PHP and Laravel, improvements to the testing setup, and some refactoring in the test files. The most important changes include updating the GitHub Actions workflow, modifying the `composer.json` dependencies, updating the PHPUnit configuration, and making several test methods static.

### Version and Dependency Updates:

* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL12-R22): Updated the PHP and Laravel versions in the matrix configuration to include PHP 8.3 and Laravel 10.* and 11.*. Adjusted the exclusions and inclusions accordingly.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L21-R27): Updated `illuminate/support` to support versions 10.* and 11.*, and updated `orchestra/testbench` and `phpunit/phpunit` to their latest versions.

### Testing Configuration:

* [`phpunit.xml.dist`](diffhunk://#diff-e35810879ec42bdd81797b3ccb72f6de28a8b4a0e3bfdba43183e133e866b892L2-R16): Updated the PHPUnit configuration to use the schema location and adjusted the source inclusion settings.

### Refactoring in Tests:

* [`tests/Integration/FormatTest.php`](diffhunk://#diff-f5898e858bb74977cab3d5c28536b63032c73844c62f4904095983981dc54518L40-R40): Changed `provideTestFormats` method to be static.
* [`tests/Integration/TestCase.php`](diffhunk://#diff-a14f3243b0def15d3525503dffab124674c7f3f611ee585458d64104da8593ecL6-R8): Renamed `TestCase` to `OrchestraTestCase` to better reflect its usage.
* [`tests/Unit/Formats/FractionFormatTest.php`](diffhunk://#diff-dfebb8786550f8ee9ac5e00c7078b29fca8f3a8e006aab9a2551f37bed839761L26-R26): Changed `provideTestFraction` and `provideTestFractionSimplified` methods to be static. [[1]](diffhunk://#diff-dfebb8786550f8ee9ac5e00c7078b29fca8f3a8e006aab9a2551f37bed839761L26-R26) [[2]](diffhunk://#diff-dfebb8786550f8ee9ac5e00c7078b29fca8f3a8e006aab9a2551f37bed839761L73-R73)
* [`tests/Unit/Formats/NumberFormatTest.php`](diffhunk://#diff-b2256cd21e4e0bb72fb751aec5229f7529c03f525a34a0bbe10718f6cd3e5376L28-R28): Changed `provideTestNumber` method to be static.
* [`tests/Unit/Formats/PercentageFormatTest.php`](diffhunk://#diff-b452bba16acce213b82aca7c1fb39e21b8d590a85eda5d242e138a8fac115772L26-R26): Changed `provideTestPercentage` method to be static.
* [`tests/Unit/TestCase.php`](diffhunk://#diff-4c9a1f3463d1483f720efa4b60a87f03e89ccf082c9db75585af56560ebd8f9cL6-R8): Renamed from `UnitTest.php` and adjusted the class name.