### PR TITLE
ci: add support for laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   tests:
@@ -10,15 +10,27 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
+        phpunit: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 11.*
+            phpunit: 12.*
+          - laravel: 12.*
+            phpunit: 12.*
+          - laravel: 13.*
+            phpunit: 11.*
+          - laravel: 13.*
+            php: 8.2
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - U${{ matrix.phpunit }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
@@ -33,7 +45,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
     "require": {
         "php": "^8.2",
         "ext-intl": "*",
-        "illuminate/support": "^11.0|^12.0"
+        "illuminate/support": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "exolnet/phpcs-config": "^2.0",
         "giggsey/libphonenumber-for-php": "^8.12",
         "laravel/pint": "^1.18.1",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^9.0|^10.0",
-        "phpunit/phpunit": "^11.5.3",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^11.5.3|^12.0",
         "squizlabs/php_codesniffer": "^3.10.3"
     },
     "suggest": {


### PR DESCRIPTION
Ref #58942

This pull request updates the testing workflow and dependencies to add support for Laravel 13 and PHPUnit 12, ensuring compatibility with the latest versions of these frameworks. The changes also improve the test matrix for more granular testing and update the `composer.json` requirements accordingly.

**Testing workflow improvements:**

* Expanded the GitHub Actions workflow trigger to include `workflow_dispatch`, allowing manual workflow runs.
* Updated the test matrix in `.github/workflows/tests.yml` to:
  - Add Laravel 13 and PHPUnit 12 as test targets.
  - Specify compatible combinations of PHP, Laravel, and PHPUnit versions, including new exclusions to avoid unsupported combinations.
  - Include the PHPUnit version in the job name for clearer identification.
  - Ensure the correct PHPUnit version is required and installed for each test run. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL13-R33) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL36-R48)

**Dependency updates:**

* Updated `composer.json` to support `illuminate/support` version 13, `orchestra/testbench` version 11, and `phpunit/phpunit` version 12 in both `require` and `require-dev` sections.